### PR TITLE
Fix a bug that causes syntax to not highlight correctly in editor.

### DIFF
--- a/src/syntax/asm.rs
+++ b/src/syntax/asm.rs
@@ -1160,21 +1160,21 @@ impl Syntax {
             ]),
             types: BTreeSet::from(["ptr", "byte", "word", "dword", "qword"]),
             special: BTreeSet::from([
-                "RAX", "RBX", "RCX", "RDX", "RSI", "RDI", "RBP", "RSP", "R8", "R9", "R10", "R11",
-                "R12", "R13", "R14", "R15", // 64-bit registers
-                "EAX", "EBX", "ECX", "EDX", "ESI", "EDI", "EBP", "ESP", "R8D", "R9D", "R10D",
-                "R11D", "R12D", "R13D", "R14D", "R15D", // 32-bit registers
-                "AX", "BX", "CX", "DX", "SI", "DI", "BP", "SP", "R8W", "R9W", "R10W", "R11W",
-                "R12W", "R13W", "R14W", "R15W", // 16-bit registers
-                "AH", "BH", "CH", "DH", "AL", "BL", "CL", "DL", "SIL", "DIL", "BPL", "SPL", "R8B",
-                "R9B", "R10B", "R11B", "R12B", "R13B", "R14B", "R15B",
+                "rax", "rbx", "rcx", "rdx", "rsi", "rdi", "rbp", "rsp", "r8", "r9", "r10", "r11",
+                "r12", "r13", "r14", "r15", // 64-bit registers
+                "eax", "ebx", "ecx", "edx", "esi", "edi", "ebp", "esp", "r8d", "r9d", "r10d",
+                "r11d", "r12d", "r13d", "r14d", "r15d", // 32-bit registers
+                "ax", "bx", "cx", "dx", "si", "di", "bp", "sp", "r8w", "r9w", "r10w", "r11w",
+                "r12w", "r13w", "r14w", "r15w", // 16-bit registers
+                "ah", "bh", "ch", "dh", "al", "bl", "cl", "dl", "sil", "dil", "bpl", "spl", "r8b",
+                "r9b", "r10b", "r11b", "r12b", "r13b", "r14b", "r15b",
                 // 8-bit registers
-                "XMM0", "XMM1", "XMM2", "XMM3", "XMM4", "XMM5", "XMM6", "XMM7", "XMM8", "XMM9",
-                "XMM10", "XMM11", "XMM12", "XMM13", "XMM14", "XMM15", // XMM
-                "YMM0", "YMM1", "YMM2", "YMM3", "YMM4", "YMM5", "YMM6", "YMM7", "YMM8", "YMM9",
-                "YMM10", "YMM11", "YMM12", "YMM13", "YMM14", "YMM15", // YMM
-                "ZMM0", "ZMM1", "ZMM2", "ZMM3", "ZMM4", "ZMM5", "ZMM6", "ZMM7", "ZMM8", "ZMM9",
-                "ZMM10", "ZMM11", "ZMM12", "ZMM13", "ZMM14", "ZMM15",
+                "xmm0", "xmm1", "xmm2", "xmm3", "xmm4", "xmm5", "xmm6", "xmm7", "xmm8", "xmm9",
+                "xmm10", "xmm11", "xmm12", "xmm13", "xmm14", "xmm15", // XMM
+                "ymm0", "ymm1", "ymm2", "ymm3", "ymm4", "ymm5", "ymm6", "ymm7", "ymm8", "ymm9",
+                "ymm10", "ymm11", "ymm12", "ymm13", "ymm14", "ymm15", // YMM
+                "zmm0", "zmm1", "zmm2", "zmm3", "zmm4", "zmm5", "zmm6", "zmm7", "zmm8", "zmm9",
+                "zmm10", "zmm11", "zmm12", "zmm13", "zmm14", "zmm15",
                 // ZMM
             ]),
         }

--- a/src/syntax/mod.rs
+++ b/src/syntax/mod.rs
@@ -174,21 +174,21 @@ impl Syntax {
         if self.case_sensitive {
             self.keywords.contains(&word)
         } else {
-            self.keywords.contains(word.to_ascii_uppercase().as_str())
+            self.keywords.contains(word.to_ascii_lowercase().as_str())
         }
     }
     pub fn is_type(&self, word: &str) -> bool {
         if self.case_sensitive {
             self.types.contains(&word)
         } else {
-            self.types.contains(word.to_ascii_uppercase().as_str())
+            self.types.contains(word.to_ascii_lowercase().as_str())
         }
     }
     pub fn is_special(&self, word: &str) -> bool {
         if self.case_sensitive {
             self.special.contains(&word)
         } else {
-            self.special.contains(word.to_ascii_uppercase().as_str())
+            self.special.contains(word.to_ascii_lowercase().as_str())
         }
     }
 }


### PR DESCRIPTION
while trying to setup syntax highlighting for an additional programming language for one of my own projects, I noticed that some symbols were not being highlighted correctly (such as keywords and variables)

the solution ended up being to replace the .to_ascii_uppercase() methods to their lowercase equivalent in src/syntax/mod.rs, as in the inbuilt languages most of the keywords are defined in lowercase, meaning many tokens would not match due to the difference in case.

before fix:
![image](https://github.com/user-attachments/assets/bf95411a-88f2-45e2-8c5c-1b90461998f1)
![image](https://github.com/user-attachments/assets/06514909-6373-4b79-a0bd-fb55334344bc)

after fix:
![image](https://github.com/user-attachments/assets/28f1fc5d-8121-4460-a901-55ab37d27fc9)
![image](https://github.com/user-attachments/assets/66aebc7b-493a-4e35-812d-ee7fef216f87)