### PR TITLE
Remove a debug print

### DIFF
--- a/src/highlighting.rs
+++ b/src/highlighting.rs
@@ -238,7 +238,6 @@ use egui::text::LayoutJob;
 #[cfg(feature = "egui")]
 impl<T: Editor> egui::util::cache::ComputerMut<(&T, &str), LayoutJob> for Token {
     fn compute(&mut self, (cache, text): (&T, &str)) -> LayoutJob {
-        println!("{text:?}");
         self.highlight(cache, text)
     }
 }


### PR DESCRIPTION
Hey! Thanks for this amazing crate.

I noticed after the latest update, my app started printing all the code in the console... this is very suboptimal for my application, since it's a programming playground, where you might want to print stuff to the console yourself.

I tracked down the culprit in your code here, apparently you left a debug print in there.

I removed it. Hope to get this merged, it's just one line removal.

Thanks again, and have a nice day!